### PR TITLE
smalltalk: Say yes to everything apt-get wants.

### DIFF
--- a/lib/travis/build/script/smalltalk.rb
+++ b/lib/travis/build/script/smalltalk.rb
@@ -102,7 +102,7 @@ module Travis
 
               sh.cmd 'sudo dpkg --add-architecture i386'
               sh.cmd 'sudo apt-get update -qq', retry: true
-              sh.cmd 'sudo apt-get install --no-install-recommends ' +
+              sh.cmd 'sudo apt-get install -y --no-install-recommends ' +
                      'libc6:i386 libuuid1:i386 libfreetype6:i386 libssl1.0.0:i386', retry: true
             end
           end
@@ -203,7 +203,7 @@ module Travis
 
               sh.cmd 'sudo dpkg --add-architecture i386'
               sh.cmd 'sudo apt-get update -qq', retry: true
-              sh.cmd 'sudo apt-get install --no-install-recommends ' +
+              sh.cmd 'sudo apt-get install -y --no-install-recommends ' +
                      'libpam0g:i386 libssl1.0.0:i386 gcc-multilib ' +
                      'libstdc++6:i386 libfreetype6:i386 pstack ' +
                      'libgl1-mesa-glx:i386 libxcb-dri2-0:i386', retry: true

--- a/spec/build/script/smalltalk_spec.rb
+++ b/spec/build/script/smalltalk_spec.rb
@@ -26,7 +26,7 @@ describe Travis::Build::Script::Smalltalk, :sexp do
       data[:config][:os] = 'linux'
     end
     it 'installs the dependencies' do
-      should include_sexp [:cmd, "sudo apt-get install --no-install-recommends libc6:i386 libuuid1:i386 libfreetype6:i386 libssl1.0.0:i386", retry: true]
+      should include_sexp [:cmd, "sudo apt-get install -y --no-install-recommends libc6:i386 libuuid1:i386 libfreetype6:i386 libssl1.0.0:i386", retry: true]
     end
   end
 
@@ -36,7 +36,7 @@ describe Travis::Build::Script::Smalltalk, :sexp do
       data[:config][:os] = 'osx'
     end
     it 'does not try to call apt-get' do
-      should_not include_sexp [:cmd, "sudo apt-get install --no-install-recommends libc6:i386 libuuid1:i386 libfreetype6:i386 libssl1.0.0:i386", retry: true]
+      should_not include_sexp [:cmd, "sudo apt-get install -y --no-install-recommends libc6:i386 libuuid1:i386 libfreetype6:i386 libssl1.0.0:i386", retry: true]
     end
   end
 
@@ -62,7 +62,7 @@ describe Travis::Build::Script::Smalltalk, :sexp do
     end
 
     it 'installs the dependencies' do
-      should include_sexp [:cmd, "sudo apt-get install --no-install-recommends " +
+      should include_sexp [:cmd, "sudo apt-get install -y --no-install-recommends " +
                      "libpam0g:i386 libssl1.0.0:i386 gcc-multilib libstdc++6:i386 " +
                      "libfreetype6:i386 pstack libgl1-mesa-glx:i386 libxcb-dri2-0:i386", retry: true]
     end
@@ -90,7 +90,7 @@ describe Travis::Build::Script::Smalltalk, :sexp do
     end
 
     it 'does not try to call apt-get' do
-      should_not include_sexp [:cmd, "sudo apt-get install --no-install-recommends " +
+      should_not include_sexp [:cmd, "sudo apt-get install -y --no-install-recommends " +
                      "libpam0g:i386 libssl1.0.0:i386 gcc-multilib libstdc++6:i386 " +
                      "libfreetype6:i386 pstack libgl1-mesa-glx:i386 libxcb-dri2-0:i386", retry: true]
     end


### PR DESCRIPTION
For precise (e.g. when using the docker service) the build is
getting stuck as apt-get is waiting for an answer. Pass the -y
option to say yes to whatever it wants.

This should fix the build of osmo-smsc when using the docker
service.
